### PR TITLE
Allow domain to be passed on command line

### DIFF
--- a/Command/Execute.php
+++ b/Command/Execute.php
@@ -86,11 +86,32 @@ class Execute {
 		printf( "$record->HostName\t\tIN\tA\t$record->Content\r\n" );
 	}
 
+        /**
+         * @param $record
+         */
+        private function outputAAAA( $record ) {
+                printf( "$record->HostName\t\tIN\tAAAA\t$record->Content\r\n" );
+        }
+
+        /**
+         * @param $record
+         */
+        private function outputNS( $record ) {
+                printf( "$record->HostName\t\tIN\tNS\t$record->Content\r\n" );
+        }
+
+        /**
+         * @param $record
+         */
+        private function outputSRV( $record ) {
+                printf( "$record->HostName\t\tIN\tSRV\t$record->Priority $record->Weight $record->Port $record->Content\r\n" );
+        }
+
 	/**
 	 * @param $record
 	 */
 	private function outputMX( $record ) {
-		printf( "$record->HostName\t\tIN\tMX\t$record->Priority\t$record->Content\r\n" );
+		printf( "$record->HostName\t\tIN\tMX\t$record->Priority $record->Content\r\n" );
 	}
 
 	/**

--- a/Command/Execute.php
+++ b/Command/Execute.php
@@ -27,6 +27,7 @@ use Garden\Cli\Cli;
  */
 class Execute {
 
+	public $domain;
 	/**
 	 * Execute constructor.
 	 * @throws \SoapFault
@@ -37,8 +38,10 @@ class Execute {
 		$cli->description( 'Extracts DomainBox DNS into Bind format for Cloudflare.' )
 		    ->opt( 'reseller:r', 'Domainbox Reseller.', true )
 		    ->opt( 'username:u', 'Username.', true )
-		    ->opt( 'password:p', 'Password for Domainbox.', true );
+		    ->opt( 'password:p', 'Password for Domainbox.', true )
+		    ->opt( 'domain:d', 'Domain / Zone to download.', true );
 		$args            = $cli->parse( $argv, true );
+		$this->domain = $args->getOpt( 'domain' );
 		$this->domainbox = new DomainBox(
 			$args->getOpt( 'reseller' ),
 			$args->getOpt( 'username' ),
@@ -56,7 +59,7 @@ class Execute {
 			$records = $this->domainbox->doCall(
 				'QueryDnsRecords',
 				array(
-					'Zone'       => 'fullworks.net',
+					'Zone'       => $this->domain,
 					'PageNumber' => $page ++,
 				)
 			);

--- a/README.md
+++ b/README.md
@@ -2,15 +2,17 @@ This is a simple PHP command line to read the Domainbox API for DNS records and 
 
 Cloudflare currently guesses common DNS records but for complex setups often misses many out resulting in errors. Cloudflare allows uploading in BIND format files ( Advanced DNS ) Domainbox has no BIND file format download
 
-Currently only handles
-A
-MX
-CNAME
-TXT 
-records
+Currently handles DNS records domainbox allow you to set via their interface...
+* A
+* AAAA
+* MX
+* CNAME
+* TXT 
+* NS
+* SRV
 
 Version 1 has no error checking.
 
 Usage
 
-php list.php  --reseller  'your reseller name'  --username 'your user name'  --password 'your password' > mydns.txt
+```php list.php  --reseller  'your reseller name'  --username 'your user name'  --password 'your password' --domain 'example.com' > mydns.txt```


### PR DESCRIPTION
I'm not a PHP coder but we are hoping to use your script to migrate over 200 domains from domainbox to dnsmadeeasy so needed this functionality and wanted to push back upstream if it was useful :-)

I hope to add support for AAAA, NS and SRV records next if interested. 